### PR TITLE
Fix NSSF Returning 403 During NSSAI Availability Update on N22 Interface

### DIFF
--- a/.github/workflows/cdac-master.yml
+++ b/.github/workflows/cdac-master.yml
@@ -41,7 +41,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8.0.0
         with:
-          version: latest
+          version: v2.2.2
           args: -v --config ./.golangci.yml --timeout=10m
 
   hadolint:

--- a/.github/workflows/iosmcn-master.yml
+++ b/.github/workflows/iosmcn-master.yml
@@ -40,7 +40,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8.0.0
         with:
-          version: latest
+          version: v2.2.2
           args: -v --config ./.golangci.yml --timeout=10m
 
   hadolint:

--- a/factory/config.go
+++ b/factory/config.go
@@ -159,8 +159,7 @@ func (c *Config) UpdateConfig(commChannel chan *protos.NetworkSliceResponse) boo
 							}
 							// Only append if a new slice
 							if !exists {
-								NssfConfig.Configuration.SupportedNssaiInPlmnList[i].SupportedSnssaiList =
-									append(NssfConfig.Configuration.SupportedNssaiInPlmnList[i].SupportedSnssaiList, *nssai)
+								NssfConfig.Configuration.SupportedNssaiInPlmnList[i].SupportedSnssaiList = append(NssfConfig.Configuration.SupportedNssaiInPlmnList[i].SupportedSnssaiList, *nssai)
 							}
 							found = true
 							break

--- a/factory/config.go
+++ b/factory/config.go
@@ -147,8 +147,21 @@ func (c *Config) UpdateConfig(commChannel chan *protos.NetworkSliceResponse) boo
 					logger.GrpcLog.Infoln("Slice Sd ", ns.Nssai.Sd)
 					sNssaiInPlmns.SupportedSnssaiList = append(sNssaiInPlmns.SupportedSnssaiList, *nssai)
 					found := false
-					for _, cplmn := range NssfConfig.Configuration.SupportedPlmnList {
-						if (cplmn.Mnc == plmn.Mnc) && (cplmn.Mcc == plmn.Mcc) {
+					for i, cplmn := range NssfConfig.Configuration.SupportedPlmnList {
+						if cplmn.Mnc == plmn.Mnc && cplmn.Mcc == plmn.Mcc {
+							// Check if the S-NSSAI exists already
+							exists := false
+							for _, existingSnssai := range NssfConfig.Configuration.SupportedNssaiInPlmnList[i].SupportedSnssaiList {
+								if existingSnssai.Sst == nssai.Sst && existingSnssai.Sd == nssai.Sd {
+									exists = true
+									break
+								}
+							}
+							// Only append if a new slice
+							if !exists {
+								NssfConfig.Configuration.SupportedNssaiInPlmnList[i].SupportedSnssaiList =
+									append(NssfConfig.Configuration.SupportedNssaiInPlmnList[i].SupportedSnssaiList, *nssai)
+							}
 							found = true
 							break
 						}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind bug fix

**What this PR does / why we need it**:
This PR fixes an issue where the NSSF returns 403 Forbidden during the NSSAI Availability Update procedure triggered by the AMF over the N22 interface. According to the 3GPP NSSF service behavior, the AMF sends: HTTPV2_NNSSF_NSSAI_AVAILABILITY_UPDATE_PUT_REQ
The expected response from NSSF is: 200 OK
However, the current implementation incorrectly rejects the update and responds with: 403 Forbidden
This PR corrects the validation and processing logic for handling NSSAI Availability Update requests, ensuring that:
Valid PLMN + NSSAI combinations configured in the system are accepted. Duplicate or repeated updates are handled gracefully. The NSSF aligns with 3GPP service expectations and passes conformance scenarios.
**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #17

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
