### PR TITLE
Fix: NSSAI Availability Patch procedure failure

### DIFF
--- a/producer/nssaiavailability_store.go
+++ b/producer/nssaiavailability_store.go
@@ -28,7 +28,7 @@ import (
 )
 
 // finds any key named "sst" with a string value, and converts it to an integer.
-func fixSstTypeInInterface(data interface{}) {
+func convertSstStrToInt(data interface{}) {
 	switch typedData := data.(type) {
 	case map[string]interface{}:
 		// It's a map, iterate through its keys
@@ -44,13 +44,13 @@ func fixSstTypeInInterface(data interface{}) {
 				}
 			} else {
 				// For any other key, recursively check its value
-				fixSstTypeInInterface(value)
+				convertSstStrToInt(value)
 			}
 		}
 	case []interface{}:
 		// It's a slice, iterate through its elements
 		for _, item := range typedData {
-			fixSstTypeInInterface(item)
+			convertSstStrToInt(item)
 		}
 	}
 }
@@ -173,7 +173,7 @@ func NSSAIAvailabilityPatchProcedure(nssaiAvailabilityUpdateInfo plugin.PatchDoc
 	}
 
 	// Recursively find and fix "sst" fields
-	fixSstTypeInInterface(genericData)
+	convertSstStrToInt(genericData)
 
 	// Marshal the fixed data back into the 'modified' variable
 	modified, err = json.Marshal(genericData)

--- a/producer/nssaiavailability_store.go
+++ b/producer/nssaiavailability_store.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strconv"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/omec-project/nssf/factory"
@@ -25,6 +26,34 @@ import (
 	"github.com/omec-project/nssf/util"
 	"github.com/omec-project/openapi/models"
 )
+
+// finds any key named "sst" with a string value, and converts it to an integer.
+func fixSstTypeInInterface(data interface{}) {
+	switch typedData := data.(type) {
+	case map[string]interface{}:
+		// It's a map, iterate through its keys
+		for key, value := range typedData {
+			if key == "sst" {
+				// Found the key we need
+				if sstString, ok := value.(string); ok {
+					// The value is a string, so we need to convert it
+					if sstInt, err := strconv.Atoi(sstString); err == nil {
+						// Conversion successful, replace the string with the integer
+						typedData[key] = sstInt
+					}
+				}
+			} else {
+				// For any other key, recursively check its value
+				fixSstTypeInInterface(value)
+			}
+		}
+	case []interface{}:
+		// It's a slice, iterate through its elements
+		for _, item := range typedData {
+			fixSstTypeInInterface(item)
+		}
+	}
+}
 
 // NSSAIAvailability DELETE method
 func NSSAIAvailabilityDeleteProcedure(nfId string) *models.ProblemDetails {
@@ -128,6 +157,31 @@ func NSSAIAvailabilityPatchProcedure(nssaiAvailabilityUpdateInfo plugin.PatchDoc
 			Title:  util.INVALID_REQUEST,
 			Status: http.StatusConflict,
 			Detail: err.Error(),
+		}
+		return nil, problemDetails
+	}
+
+	var genericData []interface{}
+	if err = json.Unmarshal(modified, &genericData); err != nil {
+		// If unmarshal fails here, the JSON is truly malformed.
+		problemDetails = &models.ProblemDetails{
+			Title:  util.MALFORMED_REQUEST,
+			Status: http.StatusBadRequest,
+			Detail: "Failed to parse patched data: " + err.Error(),
+		}
+		return nil, problemDetails
+	}
+
+	// Recursively find and fix "sst" fields
+	fixSstTypeInInterface(genericData)
+
+	// Marshal the fixed data back into the 'modified' variable
+	modified, err = json.Marshal(genericData)
+	if err != nil {
+		problemDetails = &models.ProblemDetails{
+			Title:  http.StatusText(http.StatusInternalServerError),
+			Status: http.StatusInternalServerError,
+			Detail: "Failed to re-marshal sanitized data: " + err.Error(),
 		}
 		return nil, problemDetails
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:
This PR fixes a failure in the NSSAI Availability PATCH operation (NSSAIAvailabilityPatchProcedure) caused by a data type mismatch in the incoming S-NSSAI payload.

As per the specification, patchitem may be provided in any data type. However, internal NSSF processing expects sst to be handled as an integer if sst is the item. This change introduces a normalization step that converts sst values to
integer type when present, ensuring consistent internal handling while accepting valid input formats.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#20](https://github.com/5GC-DEV/nssf-cdac/issues/20)

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
NA

**Special notes for your reviewer**:
NIL